### PR TITLE
Fix time, closes #38 #39

### DIFF
--- a/tests/test_YamlModel.py
+++ b/tests/test_YamlModel.py
@@ -254,6 +254,21 @@ class TestYamlModel(unittest.TestCase):
         model.delete_condition(condition_id)
         self.assertListEqual(model.get_condition_ids(), [])
 
+    def test_valid_model(self):
+        """
+        Tests, whether the resulting models are valid.
+        """
+        model = YamlModel()
+
+        model.set_time('t')
+        model.add_ode(state_id='x',
+                      right_hand_side='k_1 * x + t',
+                      initial_value=0)
+        model.add_parameter(parameter_id='k_1',
+                            nominal_value=1)
+
+        model.validate_model()
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()

--- a/tests/test_yaml2sbml/ode_input_invalid_time_1.yaml
+++ b/tests/test_yaml2sbml/ode_input_invalid_time_1.yaml
@@ -1,0 +1,9 @@
+time:
+  - t
+odes:
+- initialValue: 0
+  rightHandSide: k_1 * x + t
+  stateId: x
+parameters:
+- nominalValue: 1
+  parameterId: k_1

--- a/tests/test_yaml2sbml/ode_input_invalid_time_2.yaml
+++ b/tests/test_yaml2sbml/ode_input_invalid_time_2.yaml
@@ -1,0 +1,9 @@
+time:
+  - variable: t
+odes:
+- initialValue: 0
+  rightHandSide: k_1 * x + t
+  stateId: x
+parameters:
+- nominalValue: 1
+  parameterId: k_1

--- a/tests/test_yaml_validation.py
+++ b/tests/test_yaml_validation.py
@@ -36,6 +36,17 @@ class TestYamlValidation(unittest.TestCase):
         with self.assertRaises(ValidationError):
             validate_yaml(file_in)
 
+    def test_catch_invalid_time_block(self):
+        # time block without kew word "variable"
+        file_in = os.path.join(self.test_folder, 'ode_input_invalid_time_1.yaml')
+        with self.assertRaises(ValidationError):
+            validate_yaml(file_in)
+
+        # time block without kew word "variable"
+        file_in = os.path.join(self.test_folder, 'ode_input_invalid_time_2.yaml')
+        with self.assertRaises(ValidationError):
+            validate_yaml(file_in)
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()

--- a/tests/test_yaml_validation.py
+++ b/tests/test_yaml_validation.py
@@ -36,13 +36,14 @@ class TestYamlValidation(unittest.TestCase):
         with self.assertRaises(ValidationError):
             validate_yaml(file_in)
 
-    def test_catch_invalid_time_block(self):
+    def test_catch_invalid_time_block_missing_variable_key(self):
         # time block without kew word "variable"
         file_in = os.path.join(self.test_folder, 'ode_input_invalid_time_1.yaml')
         with self.assertRaises(ValidationError):
             validate_yaml(file_in)
 
-        # time block without kew word "variable"
+    def test_catch_invalid_time_block_as_array(self):
+        # time block as array instead of single object
         file_in = os.path.join(self.test_folder, 'ode_input_invalid_time_2.yaml')
         with self.assertRaises(ValidationError):
             validate_yaml(file_in)

--- a/yaml2sbml/YamlModel.py
+++ b/yaml2sbml/YamlModel.py
@@ -17,7 +17,7 @@ class YamlModel:
         """
         Set up yaml model.
         """
-        self._yaml_model = {'time': None,
+        self._yaml_model = {'time': [],
                             'odes': [],
                             'parameters': [],
                             'assignments': [],
@@ -174,7 +174,7 @@ class YamlModel:
 
         for (key, val) in self._yaml_model.items():
             if val:
-               reduced_model_dict[key] = copy.deepcopy(val)
+                reduced_model_dict[key] = copy.deepcopy(val)
 
         return reduced_model_dict
 
@@ -184,10 +184,13 @@ class YamlModel:
 
     def set_time(self,
                  time_variable: str):
-        self._yaml_model['time'] = [time_variable]
+        self._add_entry({'variable': time_variable}, 'time')
 
     def get_time(self):
-        return self._yaml_model['time'][0]
+        if self.is_set_time():
+            return self._get_ids('time', 'variable')[0]
+        else:
+            return None
 
     # functions adding a value
     def add_parameter(self,

--- a/yaml2sbml/YamlModel.py
+++ b/yaml2sbml/YamlModel.py
@@ -17,7 +17,7 @@ class YamlModel:
         """
         Set up yaml model.
         """
-        self._yaml_model = {'time': [],
+        self._yaml_model = {'time': {},
                             'odes': [],
                             'parameters': [],
                             'assignments': [],
@@ -184,11 +184,11 @@ class YamlModel:
 
     def set_time(self,
                  time_variable: str):
-        self._add_entry({'variable': time_variable}, 'time')
+        self._yaml_model['time'] = {'variable': time_variable}
 
     def get_time(self):
         if self.is_set_time():
-            return self._get_ids('time', 'variable')[0]
+            return self._yaml_model['time']['variable']
         else:
             return None
 

--- a/yaml2sbml/yaml_schema.yaml
+++ b/yaml2sbml/yaml_schema.yaml
@@ -13,7 +13,6 @@ properties:
         description: defines a time variable, in case the right hand side of the ODE is time-dependent.
     required:
       - variable
-    maxItems: 1
 
   parameters:
     type: array

--- a/yaml2sbml/yaml_schema.yaml
+++ b/yaml2sbml/yaml_schema.yaml
@@ -6,11 +6,14 @@ description: yaml2sbml file format
 properties:
 
   time:
+    type: object
     items:
       variable:
         type: string
         description: defines a time variable, in case the right hand side of the ODE is time-dependent.
-
+    required:
+      - variable
+    maxItems: 1
 
   parameters:
     type: array


### PR DESCRIPTION
- correctly sets `time` block in `YamlModel.set_time()`

- adapts the `validate_yaml` function, such that the wrong definition of the time block would have been caught... :) 