### PR TITLE
delete requirements, change to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-python-libsbml>=5.18.0
-PyYAML>=5.3
-pandas>=1.0.1
-petab>=0.1.2
-jsonschema >= 3.0.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setuptools.setup(
     install_requires=["python-libsbml>=5.18.0",
                       "PyYAML>=5.1",
                       "pandas>=1.0.1",
-                      "petab>=0.1.4"],
+                      "petab>=0.1.4",
+                      "jsonschema>=3.0.1"],
     tests_require=["amici>=0.11.10",
                    "pypesto>=0.2.2"
                    "numpy>=1.19.4",


### PR DESCRIPTION
Currently we have a requirements.txt, which is only a subset of what is specified in setup.py and even more troublesome: Some requirements are not in the setup.py