### PR TITLE
Add documentation badge to README and readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/yaml2sbml-dev/yaml2sbml/workflows/CI/badge.svg)](https://github.com/yaml2sbml-dev/yaml2sbml/actions)
 [![codecov](https://codecov.io/gh/yaml2sbml-dev/yaml2sbml/branch/master/graph/badge.svg)](https://codecov.io/gh/yaml2sbml-dev/yaml2sbml)
+[![Documentation Status](https://readthedocs.org/projects/yaml2sbml/badge/?version=latest)](https://yaml2sbml.readthedocs.io/en/latest/?badge=latest)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/632acdc8d4ef4f50bf69892b8862fd24)](https://www.codacy.com/gh/yaml2sbml-dev/yaml2sbml/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=yaml2sbml-dev/yaml2sbml&amp;utm_campaign=Badge_Grade)
 
 ## Table of contents

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,6 +7,9 @@ yaml2sbml
 .. image:: https://codecov.io/gh/yaml2sbml-dev/yaml2sbml/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/yaml2sbml-dev/yaml2sbml
    :alt: Code coverage
+.. image:: https://readthedocs.org/projects/yaml2sbml/badge/?version=latest
+   :target: https://yaml2sbml.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
 .. image:: https://app.codacy.com/project/badge/Grade/dc25c9a84ba54710bbb23a6e08ab5d22
    :target: https://www.codacy.com/manual/martamatos/yaml2sbml/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=yaml2sbml-dev/yaml2sbml&amp;utm_campaign=Badge_Grade
    :alt: Code quality


### PR DESCRIPTION
Just added the readthedocs badge to the README, that way users can also use it as a link to go to the readthedocs page straight away.