### PR TITLE
Adress comments regarding the software in the JOSS reviewing process

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -29,6 +29,16 @@ or clone the repository and install from local via::
 where ``-e`` is short for ``--editable`` and links the installed package to
 the current location, such that changes there take immediate effect.
 
+Additional dependencies for running the examples
+------------------------------------------------
+
+The notebooks come with additional dependencies. Information on the
+installation of the ODE-simulator AMICI is given in its
+`installation guide <http://sbml.org/Special/Software/libSBML/docs/formatted/python-api/libsbml-math.html>`_.
+Further dependencies can be installed via::
+
+    pip install yaml2sbml[examples]
+
 .. _Miniconda: http://conda.pydata.org/miniconda.html
 .. _PyPI: https://pypi.org/project/yaml2sbml
 .. _GitHub: https://github.com/yaml2sbml-dev/yaml2sbml

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -34,7 +34,7 @@ Additional dependencies for running the examples
 
 The notebooks come with additional dependencies. Information on the
 installation of the ODE-simulator AMICI is given in its
-`installation guide <http://sbml.org/Special/Software/libSBML/docs/formatted/python-api/libsbml-math.html>`_.
+`installation guide <https://github.com/AMICI-dev/AMICI/blob/master/INSTALL.md>`_.
 Further dependencies can be installed via::
 
     pip install yaml2sbml[examples]

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,7 +33,7 @@ Additional dependencies for running the examples
 ------------------------------------------------
 
 The notebooks come with additional dependencies. Information on the
-installation of the ODE-simulator AMICI is given in its
+installation of the ODE simulator `AMICI <https://github.com/AMICI-dev/AMICI>`_ is given in its
 `installation guide <https://github.com/AMICI-dev/AMICI/blob/master/INSTALL.md>`_.
 Further dependencies can be installed via::
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Jakob Vanhoefer, Marta R. A. Matos
+Copyright (c) 2020 Jakob Vanhoefer, Marta R. A. Matos, Dilan Pathirana,
+Yannik Schaelte and Jan Hasenauer.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/examples/Format_Features/Format_Features.ipynb
+++ b/doc/examples/Format_Features/Format_Features.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the sake of brevity, simulation and plotting is done in a separate function. Details on these steps can be found on [other notebooks](../Lotka_Volterra_python/Lotka_Volterra.ipynb)."
+    "For the sake of brevity, simulation and plotting is done in a separate function. Details on these steps can be found on [other notebooks](https://github.com/yaml2sbml-dev/yaml2sbml/tree/main/doc/examples/Lotka_Volterra)."
    ]
   },
   {

--- a/doc/examples/Format_Features/Format_Features.ipynb
+++ b/doc/examples/Format_Features/Format_Features.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "* Time-dependent right hand sides\n",
     "* Step functions in the right hand side\n",
-    "* Function definition"
+    "* Function definitions"
    ]
   },
   {

--- a/doc/examples/Format_Features/Format_Features.ipynb
+++ b/doc/examples/Format_Features/Format_Features.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "This notebook demonstrates minimal examples of the following format features:\n",
     "\n",
-    "* [Time-dependent right hand sides](.time_dependent_rhs.yml)\n",
-    "* [Step functions in the right hand side](step_function.yml)\n",
-    "* [Function definition](function_in_rhs.yml)"
+    "* Time-dependent right hand sides\n",
+    "* Step functions in the right hand side\n",
+    "* Function definition"
    ]
   },
   {

--- a/doc/examples/Format_Features/Format_Features.ipynb
+++ b/doc/examples/Format_Features/Format_Features.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the sake of brevity, simulation and plotting is done in a separate function. Details on these steps can be found on [other notebooks](https://github.com/yaml2sbml-dev/yaml2sbml/tree/main/doc/examples/Lotka_Volterra)."
+    "For the sake of brevity, simulation and plotting is done in a separate function. Details on these steps can be found in [other notebooks](https://github.com/yaml2sbml-dev/yaml2sbml/tree/main/doc/examples/Lotka_Volterra)."
    ]
   },
   {

--- a/doc/examples/README.md
+++ b/doc/examples/README.md
@@ -24,3 +24,7 @@ The [`yaml2sbml`](https://github.com/yaml2sbml-dev/yaml2sbml) package translates
         *   Time-dependent right hand sides
         *   Step functions in the right hand side
         *   Function definitions
+                
+## Running the examples
+
+The notebooks come with additional dependencies, mainly for running the ODE-simulation and parameter fitting. Information on the installation of AMICI is given in its [installation guide](http://sbml.org/Special/Software/libSBML/docs/formatted/python-api/libsbml-math.html). Further dependencies ( e.g. [pyPESTO](https://github.com/ICB-DCM/pyPESTO)) can be installed via `pip install yaml2sbml[examples]`.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 0.2.2 (2021-03-19)
 ------------------
 
-* Add checks in SBML conversion, e.g. to catch invalid identifiers and equations (# 118).
+* Add checks in SBML conversion, e.g. to catch invalid identifiers and equations (# 118, #123).
 * Add tests for MacOS and Windows (#115).
 * Fix pydocstyle and swig (#120).
 * Add a logo license. (#116)


### PR DESCRIPTION
This PR dresses the comments regarding the software made by both reviewers in the JOSS reviewing process (#125 #127). Explitiely:

- [x] The LICENSE now names all authors of the paper (#125)
- [x] extra dependencies of the examples (#125 #127): I added a section on how to pip-install these sections, where to get help e.g. for AMICI in the [documentation of the installation](https://github.com/yaml2sbml-dev/yaml2sbml/blob/feature_JOSS_review_comments_to_develop/INSTALL.rst) and the [examples/README](https://github.com/yaml2sbml-dev/yaml2sbml/tree/feature_JOSS_review_comments_to_develop/doc/examples)
- [x] The relative links in the Format-Features-notebook were not rendered correctly and were deleted. 8#127)