### PR TITLE
Avoid unit consistency checks

### DIFF
--- a/yaml2sbml/yaml2sbml.py
+++ b/yaml2sbml/yaml2sbml.py
@@ -109,6 +109,8 @@ def _parse_yaml_dict(yaml_dict: dict,
                                  observables_as_assignments)
 
     # check consistency and give warnings for errors in SBML:
+    document.setConsistencyChecks(sbml.LIBSBML_CAT_UNITS_CONSISTENCY, False)
+
     if document.checkConsistency():
 
         for error_num in range(document.getErrorLog().getNumErrors()):


### PR DESCRIPTION
Units are always dimensionless in the generated SBML models
https://github.com/yaml2sbml-dev/yaml2sbml/blob/6f42ee593796765605f2735066e157c7b1352861/yaml2sbml/yaml2sbml.py#L288
https://github.com/yaml2sbml-dev/yaml2sbml/blob/6f42ee593796765605f2735066e157c7b1352861/yaml2sbml/yaml2sbml.py#L328
https://github.com/yaml2sbml-dev/yaml2sbml/blob/6f42ee593796765605f2735066e157c7b1352861/yaml2sbml/yaml2sbml.py#L446

This can lead to inconsistent units. With the following YAML, the SBML `checkConsistency` results in a segmentation fault (`python-libsbml == 5.19.0`).
```yaml
assignments:
- assignmentId: Pprp
  formula: pow(10, log10(GlucH))
odes:
- initialValue: GlucH0
  rightHandSide: GlucH
  stateId: GlucH
parameters:
- nominalValue: 1
  parameterId: GlucH0
```

Units have no effect in SBML so these false inconsistencies can be ignored.